### PR TITLE
Update settings_default.py

### DIFF
--- a/wagtailstartproject/project_template/project_name/settings_default.py
+++ b/wagtailstartproject/project_template/project_name/settings_default.py
@@ -45,9 +45,9 @@ INSTALLED_APPS = [
     'modelcluster',
     'taggit',
 
+    'django.contrib.contenttypes',
     'django.contrib.admin',
     'django.contrib.auth',
-    'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',


### PR DESCRIPTION
To avoid funny errors like

`IntegrityError: Problem installing fixtures: insert or update on table "wagtailcore_page" violates foreign key constraint "wagtailcore__content_type_id_c28424df_fk_django_content_type_id"`

while running selenium tests