### PR TITLE
Add headless Firefox support.

### DIFF
--- a/wagtailstartproject/project_template/package.json
+++ b/wagtailstartproject/project_template/package.json
@@ -11,5 +11,6 @@
   "homepage": "https://bitbucket.org/[organisation]/{{ project_name }}",
   "devDependencies": {
     "chromedriver": "^2.31.0",
+    "geckodriver": "^1.8.1"
   }
 }

--- a/wagtailstartproject/project_template/tests/test_selenium/base.py
+++ b/wagtailstartproject/project_template/tests/test_selenium/base.py
@@ -1,7 +1,7 @@
 import unittest
 
 from itertools import chain
-from os import path, rmdir, environ
+from os import environ, path, rmdir
 from tempfile import mkdtemp
 
 from selenium import webdriver

--- a/wagtailstartproject/project_template/tests/test_selenium/test_flow.py
+++ b/wagtailstartproject/project_template/tests/test_selenium/test_flow.py
@@ -1,4 +1,4 @@
-from .base import SeleniumDesktopTestCase, SeleniumMobileTestCase
+from .base import FirefoxDriverMixin, SeleniumDesktopTestCase, SeleniumMobileTestCase
 
 
 class FlowTest(SeleniumDesktopTestCase):
@@ -14,5 +14,12 @@ class FlowTest(SeleniumDesktopTestCase):
 class MobileFlowTest(SeleniumMobileTestCase, FlowTest):
 
     """Run the tests on a mobile-like browser"""
+
+    pass
+
+
+class FirefoxFlowTest(FirefoxDriverMixin, FlowTest):
+
+    """Run the tests in the Firefox browser"""
 
     pass


### PR DESCRIPTION
Clarify that Chrome is the default browser for the SeleniumTestCase.
Add a `FirefoxDriverMixin` class to use the Firefox browser instead.
This could be converted into a subclass of `SeleniumTestCase` instead, not certain yet what the best approach is.

Firefox currently only supports the Desktop-sized version of tests, mobileEmulation is not supported. Additionally, the way in which the window size is set is different, it is set after starting the driver, not given in the options.

Moreover, in some tests I found that Firefox required some additional time (`sleep(1)`) after clicking the submit button of a form.