### PR TITLE
Generate an sql dump and run the tests from it

### DIFF
--- a/wagtailstartproject/project_template/project_name/management/commands/selenium_fixture.py
+++ b/wagtailstartproject/project_template/project_name/management/commands/selenium_fixture.py
@@ -58,7 +58,8 @@ class Command(BaseCommand):
         )
 
         # TODO: find a way to have it anonymized
-        subprocess.call([
+        subprocess.call(
+            [
                 'pg_dump',
                 '--no-owner',
                 '--no-privileges',

--- a/wagtailstartproject/project_template/project_name/management/commands/selenium_fixture.py
+++ b/wagtailstartproject/project_template/project_name/management/commands/selenium_fixture.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 
 from django.conf import settings
 from django.core.management import BaseCommand, call_command
@@ -45,12 +46,23 @@ class Command(BaseCommand):
             'wagtailcore.groupcollectionpermission',
         ]
 
-        path = os.path.join(settings.BASE_DIR, 'tests/fixtures/basic_site.json')
+        json_path = os.path.join(settings.BASE_DIR, 'tests/fixtures/basic_site.json')
+        sql_path = os.path.join(settings.BASE_DIR, 'tests/fixtures/basic_site.sql')
 
         call_command(
             'dumpdata',
             exclude=excluded,
             natural_foreign=True,
             indent=2,
-            output=path
+            output=json_path
+        )
+
+        # TODO: find a way to have it anonymized
+        subprocess.call([
+                'pg_dump',
+                '--no-owner',
+                '--no-privileges',
+                '--file={file}'.format(file=sql_path),
+                '{dbname}'.format(dbname=settings.DATABASES.get('default').get('NAME')),
+            ]
         )

--- a/wagtailstartproject/project_template/runtests.py
+++ b/wagtailstartproject/project_template/runtests.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import os
 import sys
+import argparse
 
 import django
 
@@ -9,17 +10,37 @@ from django.test.runner import default_test_processes
 from django.test.utils import get_runner
 
 
-def runtests():
+def runtests(args):
     os.environ['DJANGO_SETTINGS_MODULE'] = 'tests.test_settings'
     django.setup()
+
+    if args.sql:
+        settings.TEST_RUNNER = 'tests.runner.KeepDBRunner'
+
     test_runner = get_runner(settings)
-    if sys.argv[0] != 'setup.py' and len(sys.argv) > 1:
-        tests = sys.argv[1:]
-    else:
-        tests = ['tests']
-    failures = test_runner(parallel=default_test_processes()).run_tests(tests)
+    failures = test_runner(parallel=args.parallel).run_tests(args.tests)
     sys.exit(bool(failures))
 
 
 if __name__ == '__main__':
-    runtests()
+    parser = argparse.ArgumentParser(description='Run tests')
+    parser.add_argument(
+        dest='tests',
+        metavar='testcase',
+        nargs='*',
+        default=['tests'],
+        help='an optional list of test cases to run'
+    )
+    parser.add_argument(
+        '--sql',
+        action='store_true',
+        help='load an sql file and ignore the json fixtures during the tests'
+    )
+    parser.add_argument(
+        '--parallel',
+        action='store_true',
+        help='run multiple tests in parallel'
+    )
+
+    args = parser.parse_args()
+    runtests(args)

--- a/wagtailstartproject/project_template/runtests.py
+++ b/wagtailstartproject/project_template/runtests.py
@@ -17,7 +17,7 @@ def runtests(args):
     if args.parallel:
         parallel = default_test_processes()
     else:
-        parallel = 0
+        parallel = 1  # or 0 would have the same outcome; no parallel testing
 
     if args.sql:
         settings.TEST_RUNNER = 'tests.runner.KeepDBRunner'

--- a/wagtailstartproject/project_template/runtests.py
+++ b/wagtailstartproject/project_template/runtests.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
+import argparse
 import os
 import sys
-import argparse
 
 import django
 
 from django.conf import settings
-from django.test.runner import default_test_processes
 from django.test.utils import get_runner
 
 

--- a/wagtailstartproject/project_template/runtests.py
+++ b/wagtailstartproject/project_template/runtests.py
@@ -6,6 +6,7 @@ import sys
 import django
 
 from django.conf import settings
+from django.test.runner import default_test_processes
 from django.test.utils import get_runner
 
 
@@ -13,11 +14,16 @@ def runtests(args):
     os.environ['DJANGO_SETTINGS_MODULE'] = 'tests.test_settings'
     django.setup()
 
+    if args.parallel:
+        parallel = default_test_processes()
+    else:
+        parallel = 0
+
     if args.sql:
         settings.TEST_RUNNER = 'tests.runner.KeepDBRunner'
 
     test_runner = get_runner(settings)
-    failures = test_runner(parallel=args.parallel).run_tests(args.tests)
+    failures = test_runner(parallel=parallel).run_tests(args.tests)
     sys.exit(bool(failures))
 
 

--- a/wagtailstartproject/project_template/tests/runner.py
+++ b/wagtailstartproject/project_template/tests/runner.py
@@ -9,6 +9,11 @@ from django.test.runner import DiscoverRunner, get_unique_databases_and_mirrors
 
 class KeepDBRunner(DiscoverRunner):
     def setup_databases(self, **kwargs):
+        """
+        Mostly the same as the parent logic except we need to populate the database with the content of the SQL file
+        before running the migrations.
+
+        """
         test_databases, mirrored_aliases = get_unique_databases_and_mirrors()
 
         old_names = []
@@ -22,6 +27,8 @@ class KeepDBRunner(DiscoverRunner):
                 # Actually create the database for the first connection
                 if first_alias is None:
                     first_alias = alias
+
+                    # --- From here, copy and change BaseDatabaseCreation.create_test_db
 
                     connection_creation = connection.creation
                     test_database_name = connection_creation._get_test_db_name()
@@ -59,6 +66,8 @@ class KeepDBRunner(DiscoverRunner):
                         database=connection_creation.connection.alias,
                         run_syncdb=True,
                     )
+
+                    # --- Til here. Then again, same as DiscoverRunner.setup_databases
 
                     if self.parallel > 1:
                         for index in range(self.parallel):

--- a/wagtailstartproject/project_template/tests/runner.py
+++ b/wagtailstartproject/project_template/tests/runner.py
@@ -1,0 +1,89 @@
+import os
+import subprocess
+
+from django.core.management import call_command
+from django.db import connections
+from django.conf import settings
+
+try:
+    import tblib.pickling_support
+except ImportError:
+    tblib = None
+from django.test.runner import DiscoverRunner, get_unique_databases_and_mirrors
+
+
+class KeepDBRunner(DiscoverRunner):
+    def setup_databases(self, **kwargs):
+        test_databases, mirrored_aliases = get_unique_databases_and_mirrors()
+
+        old_names = []
+
+        for signature, (db_name, aliases) in test_databases.items():
+            first_alias = None
+            for alias in aliases:
+                connection = connections[alias]
+                old_names.append((connection, db_name, first_alias is None))
+
+                # Actually create the database for the first connection
+                if first_alias is None:
+                    first_alias = alias
+
+                    connection_creation = connection.creation
+                    test_database_name = connection_creation._get_test_db_name()
+
+                    #create the database
+                    connection_creation._create_test_db(
+                        verbosity=self.verbosity,
+                        autoclobber=not self.interactive,
+                        keepdb=self.keepdb,
+                    )
+                    connection_creation.connection.close()
+                    settings.DATABASES[connection_creation.connection.alias]["NAME"] = test_database_name
+                    connection_creation.connection.settings_dict["NAME"] = test_database_name
+
+                    # Create the tables using to the SQL dump
+                    FNULL = open(os.devnull, 'w')
+                    # using psql because we do a full restore anyways
+                    # https://www.postgresql.org/message-id/NEBBLAAHGLEEPCGOBHDGAECGHEAA.nickf%40ontko.com
+                    subprocess.call([
+                            'psql',
+                            '{dbname}'.format(dbname=settings.DATABASES.get('default').get('TEST').get('NAME')),
+                            '--file={dir}{sqldump_path}'.format(
+                                dir=settings.FIXTURE_DIRS[0],
+                                sqldump_path='basic_site.sql',
+                            )
+                        ],
+                        stdout=FNULL
+                    )
+
+                    # Only run the migrations that are newer than what the original database knows about
+                    call_command(
+                        'migrate',
+                        verbosity=max(self.verbosity - 1, 0),
+                        interactive=False,
+                        database=connection_creation.connection.alias,
+                        run_syncdb=True,
+                    )
+
+                    if self.parallel > 1:
+                        for index in range(self.parallel):
+                            connection.creation.clone_test_db(
+                                number=index + 1,
+                                verbosity=self.verbosity,
+                                keepdb=self.keepdb,
+                            )
+                # Configure all other connections as mirrors of the first one
+                else:
+                    connections[alias].creation.set_as_test_mirror(
+                        connections[first_alias].settings_dict)
+
+        # Configure the test mirrors.
+        for alias, mirror_alias in mirrored_aliases.items():
+            connections[alias].creation.set_as_test_mirror(
+                connections[mirror_alias].settings_dict)
+
+        if self.debug_sql:
+            for alias in connections:
+                connections[alias].force_debug_cursor = True
+
+        return old_names


### PR DESCRIPTION
Create our own runner to have a custom database setup using an sql dump file to run the tests from the database as it is in production (ignoring any possible migrations/missing constraints problems).

Use that custom runner only if the `--sql` option is used while calling the existing `runtests.py` script.

The migrations are still run after the sql dump has been set up.

More comments to come about what steps have been skipped compared to the normal database setup...