### PR TITLE
Include json and cfg files for templating

### DIFF
--- a/wagtailstartproject/project_template/package.json
+++ b/wagtailstartproject/project_template/package.json
@@ -1,10 +1,14 @@
 {
-  "name": "",
+  "name": "{{ project_name }}",
   "version": "0.0.1",
-  "description": "",
+  "description": "{{ project_name }}",
+  "repository": {
+    "type": "git",
+    "url": "git@bitbucket.org:[organisation]/{{ project_name }}.git"
+  },
   "author": "",
   "license": "UNLICENSED",
-  "dependencies": {},
+  "homepage": "https://bitbucket.org/[organisation]/{{ project_name }}",
   "devDependencies": {
     "chromedriver": "^2.31.0",
   }

--- a/wagtailstartproject/project_template/package.json
+++ b/wagtailstartproject/project_template/package.json
@@ -1,14 +1,10 @@
 {
-  "name": "{{ project_name }}",
+  "name": "",
   "version": "0.0.1",
-  "description": "{{ project_name }}",
-  "repository": {
-    "type": "git",
-    "url": "git@bitbucket.org:[organisation]/{{ project_name }}.git"
-  },
+  "description": "",
   "author": "",
   "license": "UNLICENSED",
-  "homepage": "https://bitbucket.org/[organisation]/{{ project_name }}",
+  "dependencies": {},
   "devDependencies": {
     "chromedriver": "^2.31.0",
   }

--- a/wagtailstartproject/wagtailstartproject.py
+++ b/wagtailstartproject/wagtailstartproject.py
@@ -49,7 +49,7 @@ def create_project(project_name, legacy=False):
     utility_args = ['django-admin.py',
                     'startproject',
                     '--template=' + template_path,
-                    '--extension=py,ini,html,rst',
+                    '--extension=py,ini,html,rst,json,cfg',
                     project_name]
 
     # always put the project template inside the current directory:


### PR DESCRIPTION
Remove {{ project_name }} from package.json since django project-template does not replace it