### PR TITLE
Add --headful and --parallel as runtests.py params

### DIFF
--- a/wagtailstartproject/project_template/runtests.py
+++ b/wagtailstartproject/project_template/runtests.py
@@ -37,7 +37,7 @@ if __name__ == '__main__':
         nargs='?',
         const=default_test_processes(),  # arg is given without value
         default=1,  # arg is not given
-        help='do run multiple tests in parallel (how many if specified, else as many as possible)'
+        help='do run multiple tests in parallel (how many if specified, else equal to number of processors)'
     )
     parser.add_argument(
         '--headful',

--- a/wagtailstartproject/project_template/runtests.py
+++ b/wagtailstartproject/project_template/runtests.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import argparse
 import os
 import sys
 
@@ -12,14 +13,37 @@ from django.test.utils import get_runner
 def runtests():
     os.environ['DJANGO_SETTINGS_MODULE'] = 'tests.test_settings'
     django.setup()
+
+    if args.headful:
+        settings.HEADLESS = False
+
     test_runner = get_runner(settings)
-    if sys.argv[0] != 'setup.py' and len(sys.argv) > 1:
-        tests = sys.argv[1:]
-    else:
-        tests = ['tests']
-    failures = test_runner(parallel=default_test_processes()).run_tests(tests)
+    failures = test_runner(parallel=args.parallel).run_tests(args.tests)
     sys.exit(bool(failures))
 
 
 if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Run tests')
+    parser.add_argument(
+        dest='tests',
+        metavar='testcase',
+        nargs='*',
+        default=['tests'],
+        help='an optional list of test cases to run'
+    )
+    parser.add_argument(
+        '--parallel',
+        type=int,
+        nargs='?',
+        const=default_test_processes(),  # arg is given without value
+        default=1,  # arg is not given
+        help='do run multiple tests in parallel (how many if specified, else as many as possible)'
+    )
+    parser.add_argument(
+        '--headful',
+        action='store_true',
+        help='do not run headless (checkout tests running onscreen)'
+    )
+
+    args = parser.parse_args()
     runtests()

--- a/wagtailstartproject/project_template/tests/test_selenium/base.py
+++ b/wagtailstartproject/project_template/tests/test_selenium/base.py
@@ -10,6 +10,7 @@ from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.support.expected_conditions import staleness_of
 from selenium.webdriver.support.ui import WebDriverWait
 
+from django.conf import settings
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.core.urlresolvers import Resolver404, resolve
 from django.test.runner import RemoteTestResult
@@ -80,7 +81,7 @@ class SeleniumTestCase(StaticLiveServerTestCase):
         """Setup a Chrome webdriver"""
 
         options = webdriver.ChromeOptions()
-        options.add_argument('headless')
+        options.set_headless(headless=getattr(settings, 'HEADLESS', True))
         cls.set_driver_options(options)
         try:
             driver = webdriver.Chrome('./node_modules/.bin/chromedriver', chrome_options=options)
@@ -176,6 +177,7 @@ class FirefoxDriverMixin(object):
         environ['MOZ_HEADLESS'] = "1"
         options = webdriver.firefox.options.Options()
         cls.set_driver_options(options)
+        options.set_headless(headless=getattr(settings, 'HEADLESS', True))
         try:
             driver = webdriver.Firefox(executable_path='./node_modules/.bin/geckodriver', firefox_options=options)
         except WebDriverException:

--- a/wagtailstartproject/project_template/tests/test_selenium/base.py
+++ b/wagtailstartproject/project_template/tests/test_selenium/base.py
@@ -176,8 +176,8 @@ class FirefoxDriverMixin(object):
 
         environ['MOZ_HEADLESS'] = "1"
         options = webdriver.firefox.options.Options()
-        cls.set_driver_options(options)
         options.set_headless(headless=getattr(settings, 'HEADLESS', True))
+        cls.set_driver_options(options)
         try:
             driver = webdriver.Firefox(executable_path='./node_modules/.bin/geckodriver', firefox_options=options)
         except WebDriverException:

--- a/wagtailstartproject/project_template/tests/test_settings.py
+++ b/wagtailstartproject/project_template/tests/test_settings.py
@@ -34,3 +34,6 @@ EMAIL_BACKEND = 'django.core.mail.backends.dummy.EmailBackend'
 
 # Disable the automatic indexing (sigals) of your search backend
 # In WAGTAILSEARCH_BACKENDS set AUTO_UPDATE for each backend to False
+
+# Run tests headless by default
+HEADLESS = True


### PR DESCRIPTION
Make it possible to specify headlessness (--headful) and parallelness (--parallel=N or --parallel) of tests (both optional)