### PR TITLE
Reset Content-Length after changing the length of the response

### DIFF
--- a/wagtailstartproject/project_template/tests/middleware.py
+++ b/wagtailstartproject/project_template/tests/middleware.py
@@ -17,8 +17,12 @@ class PageStatusMiddleware(MiddlewareMixin):
         if 'html' in response['Content-Type'].lower():
             response.content = response.content.replace(
                 b'</head>',
-                bytes('<meta name="status_code" content="{status_code}" /></head>'.format(status_code=response.status_code), encoding='ascii'),
+                bytes(
+                    '<meta name="status_code" content="{status_code}" /></head>'.format(status_code=response.status_code),
+                    encoding='ascii'
+                ),
                 1
             )
+            response['Content-Length'] = str(len(response.content))
 
         return response


### PR DESCRIPTION
Not sure it is actually necessary but sounds logical to do?..

> ConditionalGetMiddleware no longer sets the Date header as Web servers set that header. It also no longer sets the Content-Length header as this is now done by CommonMiddleware.
> 
> If you have a middleware that modifies a response’s content and appears before CommonMiddleware in the MIDDLEWARE or MIDDLEWARE_CLASSES settings, you must reorder your middleware so that responses aren’t modified after Content-Length is set, or have the response modifying middleware reset the Content-Length header.
https://docs.djangoproject.com/en/2.0/releases/1.11/#miscellaneous